### PR TITLE
ci/cd워크플로우 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,4 +63,4 @@ jobs:
           docker stop ${{ env.NAME }} || true
           docker rm ${{ env.NAME }} || true
           docker rmi ${{ env.DOCKER_IMAGE }}:latest || true
-          docker run -d -p 80:3000 --name ${{ env.NAME }} --restart always ${{ env.DOCKER_IMAGE }}:latest
+          docker run --env-file ./.env -d -p 80:3000 --name ${{ env.NAME }} --restart always ${{ env.DOCKER_IMAGE }}:latest


### PR DESCRIPTION
## 🔗 관련 이슈
#7
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
ec2에서  env 파일 참조를 못하길레 살펴봤는데 docker를 run 시키는 명령어 부분에 env를 참조하는 부분이 빠져있는 것 같아서 추가했습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 워크플로우가 env를 참조하도록 명령어 변경


## 💬리뷰 요구사항 (선택사항)
