### PR TITLE
ci/cd워크플로우 재수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,4 +63,4 @@ jobs:
           docker stop ${{ env.NAME }} || true
           docker rm ${{ env.NAME }} || true
           docker rmi ${{ env.DOCKER_IMAGE }}:latest || true
-          docker run --env-file ./.env -d -p 80:3000 --name ${{ env.NAME }} --restart always ${{ env.DOCKER_IMAGE }}:latest
+          docker run --env-file /home/ubuntu/.env -d -p 80:3000 --name ${{ env.NAME }} --restart always ${{ env.DOCKER_IMAGE }}:latest


### PR DESCRIPTION
## 🔗 관련 이슈
#7
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
이슈에서도 언급했지만 깃헙액션은 셀프 호스티드 러너라는 독립적인 실행 환경에서 실행되기 때문에 `./.env`같이 상대경로로는 env파일을 접근할 수 없는 것 같습니다. 
따라서 /home/ubuntu/.env로 변경했습니다..
개인 브렌치에서 테스트해본결과 잘 되는 것 같습니다
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] env 연결 절대경로로 변경


## 💬리뷰 요구사항 (선택사항)
