### PR TITLE
구분자 변경

### DIFF
--- a/src/features/quiz/service/utils.ts
+++ b/src/features/quiz/service/utils.ts
@@ -11,9 +11,9 @@ export const parseQuizData = (
     title: quizFormData.title.toString(),
     category: quizFormData.category as Category,
     question: quizFormData.question.toString(),
-    answer: isString(quizFormData.answer) ? quizFormData.answer.split(',') : [],
+    answer: isString(quizFormData.answer) ? quizFormData.answer.split('#') : [],
     answerChoice: isString(quizFormData.answerChoice)
-      ? quizFormData.answerChoice.split(',')
+      ? quizFormData.answerChoice.split('#')
       : [],
   };
 };

--- a/src/features/quiz/ui/QuizForm.tsx
+++ b/src/features/quiz/ui/QuizForm.tsx
@@ -18,7 +18,7 @@ export function QuizForm({ prevQuiz, closeModal, mod }: QuizFormProps) {
   );
 
   const [quizFilters, setQuizFilters] = useState<QuizFilters>({
-    partId: 0,
+    partId: prevQuiz?.partId ?? 0,
     sectionId: 0,
   });
 

--- a/src/features/quiz/ui/QuizForm.tsx
+++ b/src/features/quiz/ui/QuizForm.tsx
@@ -66,6 +66,8 @@ export function QuizForm({ prevQuiz, closeModal, mod }: QuizFormProps) {
 
   const isChoiceRequired =
     selectedCategory && VAILD_CATEGORIES.includes(selectedCategory);
+  const parsedAnswerChoice = prevQuiz && prevQuiz.answerChoice.join('#');
+  const parsedAnswer = prevQuiz && prevQuiz.answer.join('#');
 
   return (
     <Form onSubmit={handleMutate}>
@@ -127,7 +129,7 @@ export function QuizForm({ prevQuiz, closeModal, mod }: QuizFormProps) {
             size="sm"
             type="text"
             style={{ height: '150px' }}
-            defaultValue={prevQuiz?.answer}
+            defaultValue={parsedAnswer ?? ''}
           />
         </FloatingLabel>
         {isChoiceRequired && (
@@ -138,7 +140,7 @@ export function QuizForm({ prevQuiz, closeModal, mod }: QuizFormProps) {
               type="text"
               as="textarea"
               name="answerChoice"
-              defaultValue={prevQuiz?.answerChoice}
+              defaultValue={parsedAnswerChoice ?? ''}
               style={{ height: '150px' }}
             />
           </FloatingLabel>


### PR DESCRIPTION
## 🔗 관련 이슈
#47 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
기존 정답, 보기를 구분하기 위한 구분자로 `,`를 사용했는데 객체 프로퍼티 여러개가 정답인 경우 
ex) { a: 12, b:2 } 이런 경우에 저 `,`를 기준으로 나눠버려서 불편함이 있었습니다
그래서 잘 사용하지 않는 #으로 구분자를 변경시켰습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
